### PR TITLE
Clarify "rule" vs "property"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Don't `!important`
   - Ever.
   - If you must, leave a comment, and prioritise resolving specificity issues before resorting to `!important`.
-  - `!important` greatly increases the power of a CSS property, making it extremely tough to override in the future. It’s only possible to override with another `!important` property later in the cascade.
+  - `!important` greatly increases the power of a CSS declaration, making it extremely tough to override in the future. It’s only possible to override with another `!important` declaration later in the cascade.
 - Don’t use `margin-top`.
   - Vertical margins [collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing). Always prefer `padding-top` or`margin-bottom` on preceding elements
 - Avoid shorthand properties (unless you really need them)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Don't `!important`
   - Ever.
   - If you must, leave a comment, and prioritise resolving specificity issues before resorting to `!important`.
-  - `!important` greatly increases the power of a CSS rule, making it extremely tough to override in the future. It’s only possible to override with another `!important` rule later in the cascade.
+  - `!important` greatly increases the power of a CSS property, making it extremely tough to override in the future. It’s only possible to override with another `!important` property later in the cascade.
 - Don’t use `margin-top`.
   - Vertical margins [collapse](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing). Always prefer `padding-top` or`margin-bottom` on preceding elements
 - Avoid shorthand properties (unless you really need them)
@@ -32,7 +32,7 @@
   - E.g. `color: red;` instead of `color:red;`
 - Put spaces before `{` in rule declarations
   - E.g. `.o-modal {` instead of `.o-modal{`
-- Write your CSS one line per rule
+- Write your CSS one line per property
 - Add a line break after `}` closing rule declarations
 - When grouping selectors, keep individual selectors on a single line
 - Place closing braces `}` on a new line
@@ -44,7 +44,7 @@
 - All selectors are lower case, hyphen separated aka “spinal case” eg. `.my-class-name`
 - Always prefer Sass’s double-slash `//` commenting, even for block comments
 - Avoid specifying units for zero values, e.g. `margin: 0;` instead of `margin: 0px;`
-- Always add a semicolon to the end of a property/value rule
+- Always add a semicolon to the end of a property/value declaration
 - Use leading zeros for decimal values `opacity: 0.4;` instead of `opacity: .4;`
 - Put spaces before and after child selector `div > span` instead of `div>span`
 


### PR DESCRIPTION
The goal of this change is to clarify the terms "rule" and "property" so that "rule" refers to the selector followed by a declaration block and "property" refers to the properties inside the declaration block as specified in CSS Syntax:
- CSS 2 §4.1.7 Rule sets, declaration blocks, and selectors: https://www.w3.org/TR/CSS2/syndata.html#rule-sets
- CSS Syntax Module Level 3 (CR) §2 Description of CSS’s Syntax: https://www.w3.org/TR/css-syntax-3/#syntax-description
